### PR TITLE
Add making mvnw executable to avoid "Permission denied" error

### DIFF
--- a/.github/workflows/01-bootstrap.yml
+++ b/.github/workflows/01-bootstrap.yml
@@ -40,4 +40,5 @@ jobs:
           AWS_DEFAULT_REGION: ${{ secrets.AWS_REGION }}
         run: |
           cd cdk
+          chmod +x mvnw
           npm run repository:deploy

--- a/.github/workflows/02-create-environment.yml
+++ b/.github/workflows/02-create-environment.yml
@@ -34,4 +34,5 @@ jobs:
           AWS_DEFAULT_REGION: ${{ secrets.AWS_REGION }}
         run: |
           cd cdk
+          chmod +x mvnw
           npm run network:deploy -- -c environmentName=${{ github.event.inputs.environmentName }}


### PR DESCRIPTION
Got a permission error when running these scripts:

    > cdk deploy --app "./mvnw -e -q compile exec:java -Dexec.mainClass=de.stevenschwenke.aws.stratospheric.cdk.NetworkApp" -c environmentName=staging -c applicationName=network-app -c accountId=582070606165 -c region=*** --require-approval never "-c" "environmentName=staging"
    /bin/sh: 1: ./mvnw: Permission denied

[Extended logs in this CI run.](https://github.com/stevenschwenke/stratospheric-todoApp/runs/3804757617?check_suite_focus=true)

Adding a chmod solved the problem.