### PR TITLE
Use GitHub's concurrency feature

### DIFF
--- a/.github/workflows/04-publish-todo-app.yml
+++ b/.github/workflows/04-publish-todo-app.yml
@@ -53,7 +53,7 @@ jobs:
         run: echo "::set-output name=tag::$(date +'%Y%m%d%H%M%S')-${GITHUB_SHA}"
 
       - name: Publish Docker image to ECR registry
-        # if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
         env:
           DOCKER_IMAGE_TAG: ${{ steps.dockerImageTag.outputs.tag }}
         working-directory: application
@@ -83,7 +83,7 @@ jobs:
     name: Deploy Todo App
     needs: build-and-publish
     timeout-minutes: 15
-    # if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main'
     concurrency: todo-application-deployment
     steps:
 

--- a/.github/workflows/04-publish-todo-app.yml
+++ b/.github/workflows/04-publish-todo-app.yml
@@ -81,7 +81,7 @@ jobs:
   deploy:
     runs-on: ubuntu-20.04
     name: Deploy Todo App
-    needs: build-and-push
+    needs: build-and-publish
     timeout-minutes: 15
     # if: github.ref == 'refs/heads/main'
     concurrency: todo-application-deployment

--- a/.github/workflows/04-publish-todo-app.yml
+++ b/.github/workflows/04-publish-todo-app.yml
@@ -53,7 +53,7 @@ jobs:
         run: echo "::set-output name=tag::$(date +'%Y%m%d%H%M%S')-${GITHUB_SHA}"
 
       - name: Publish Docker image to ECR registry
-        if: github.ref == 'refs/heads/main'
+        # if: github.ref == 'refs/heads/main'
         env:
           DOCKER_IMAGE_TAG: ${{ steps.dockerImageTag.outputs.tag }}
         working-directory: application
@@ -65,7 +65,7 @@ jobs:
           docker push ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/todo-app:${DOCKER_IMAGE_TAG}
           docker push ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/todo-app:latest
 
-#      Supereseeded by GitHub Action's concurrency support
+#      Superseded by GitHub Action's concurrency support, see below
 #      - name: Sending deployment event to queue
 #        if: github.ref == 'refs/heads/main'
 #        env:

--- a/.github/workflows/04-publish-todo-app.yml
+++ b/.github/workflows/04-publish-todo-app.yml
@@ -19,6 +19,8 @@ jobs:
   build-and-publish:
     runs-on: ubuntu-20.04
     name: Build and publish Todo App
+    outputs:
+      dockerImageTag: ${{ steps.dockerImageTag.outputs.tag }}
     steps:
 
       - name: Checkout code
@@ -63,14 +65,50 @@ jobs:
           docker push ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/todo-app:${DOCKER_IMAGE_TAG}
           docker push ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/todo-app:latest
 
-      - name: Sending deployment event to queue
-        if: github.ref == 'refs/heads/main'
-        env:
-          DOCKER_IMAGE_TAG: ${{ steps.dockerImageTag.outputs.tag }}
+#      Supereseeded by GitHub Action's concurrency support
+#      - name: Sending deployment event to queue
+#        if: github.ref == 'refs/heads/main'
+#        env:
+#          DOCKER_IMAGE_TAG: ${{ steps.dockerImageTag.outputs.tag }}
+#        run: |
+#          export EVENT_PAYLOAD="{\"commitSha\": \"$GITHUB_SHA\", \"ref\": \"main\", \"owner\": \"stratospheric-dev\", \"repo\": \"stratospheric\", \"workflowId\": \"05-update-todo-app-in-staging.yml\", \"dockerImageTag\": \"$DOCKER_IMAGE_TAG\"}"
+#          aws sqs send-message \
+#            --queue-url=https://sqs.eu-central-1.amazonaws.com/221875718260/todo-app-deploymentsQueue.fifo \
+#            --message-group-id default \
+#            --message-deduplication-id $GITHUB_SHA \
+#            --message-body "$EVENT_PAYLOAD"
+
+  deploy:
+    runs-on: ubuntu-20.04
+    name: Deploy Todo App
+    needs: build-and-push
+    timeout-minutes: 15
+    # if: github.ref == 'refs/heads/main'
+    concurrency: todo-application-deployment
+    steps:
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: 'maven'
+
+      - name: NPM install
+        working-directory: cdk
+        run: npm install
+
+      - name: Deploy service stack
+        working-directory: cdk
+        run: npm run service:deploy -- -c dockerImageTag=${{ needs.build-and-publish.outputs.dockerImageTag }}
+
+      # Each Service stack updates creates a new parameter stack that CloudFormation does not clean up for us.
+      # This step deletes all "*Service-Parameters*" stacks except the latest one to keep the house clean.
+      - name: Clean up old parameter stacks
+        working-directory: cdk
         run: |
-          export EVENT_PAYLOAD="{\"commitSha\": \"$GITHUB_SHA\", \"ref\": \"main\", \"owner\": \"stratospheric-dev\", \"repo\": \"stratospheric\", \"workflowId\": \"05-update-todo-app-in-staging.yml\", \"dockerImageTag\": \"$DOCKER_IMAGE_TAG\"}"
-          aws sqs send-message \
-            --queue-url=https://sqs.eu-central-1.amazonaws.com/221875718260/todo-app-deploymentsQueue.fifo \
-            --message-group-id default \
-            --message-deduplication-id $GITHUB_SHA \
-            --message-body "$EVENT_PAYLOAD"
+          aws cloudformation describe-stacks --region eu-central-1 --query "Stacks[].StackName" --output text | sed -e "s/\s\+/\n/g" | grep -e "staging-todo-app-Service-Parameters" | sort -r | tail -n+2 > stacks_to_be_deleted.txt
+          for stack in $(cat stacks_to_be_deleted.txt); do aws cloudformation delete-stack --stack-name $stack --region eu-central-1;  done


### PR DESCRIPTION
With our deployment sequencer, we solved the problem back then to sequence the deployments and avoiding concurrent deployments.

In the meantime, GitHub added such a feature to their GitHub Actions: https://docs.github.com/en/actions/using-jobs/using-concurrency - a reader made us aware of this feature some months ago.

I'd recommend to use this feature as I see a drawback of our current setup as the final deployment step is executed asynchronously in the context of Tom's GitHub account (the sequencer uses a personalized GHA token form him). This makes it likely for us to forget to check if the deployment did succeed as we won't get a notification via email (Tom gets this email).

See an example here:

<img width="968" alt="grafik" src="https://user-images.githubusercontent.com/14176609/167077861-18d0ae63-2c92-43bd-af98-3427cbd534c4.png">

With the concurrency feature, we have the same functionality as with our existing lambda plus each commit on `main` has now green/red ticks if all pipelines went through (including the deployment to).

I'd leave the deployment sequencer in the book as it's a nice usage of Lambda + SQS but rephrase the relevant sections .