### PR TITLE
Chapter 1: fix Dockerfile

### DIFF
--- a/chapters/chapter-1/application/Dockerfile
+++ b/chapters/chapter-1/application/Dockerfile
@@ -1,6 +1,6 @@
 FROM eclipse-temurin:17-jre
 
 ARG JAR_FILE=build/libs/*.jar
-COPY ${JAR_FILE} app.jar
+COPY ${JAR_FILE} /
 
 ENTRYPOINT ["java", "-jar", "/app.jar"]


### PR DESCRIPTION
If you try to build the Docker image of chapter 1, the following warning/error is displayed and the image is not built:

`When using COPY with more than one source file, the destination must be a directory and end with a /`