### PR TITLE
Chapter 1: disable generation of plain jar

### DIFF
--- a/chapters/chapter-1/application/build.gradle
+++ b/chapters/chapter-1/application/build.gradle
@@ -31,3 +31,7 @@ bootRun {
     "-Dspring.profiles.active=dev",
   ]
 }
+
+jar {
+    enabled = false
+}


### PR DESCRIPTION
After upgrading to Spring Boot >= 2.5.0 a new jar started to be generated in the 'build/libs' directory:

`todo-application-0.0.1-SNAPSHOT.jar`
`todo-application-0.0.1-SNAPSHOT-plain.jar`

These break the generation of the Docker image.

This PR disables the generation of the plain jar.