### PR TITLE
consistently follow the least privilege principle for our IAM role

### DIFF
--- a/.github/workflows/04-publish-todo-app.yml
+++ b/.github/workflows/04-publish-todo-app.yml
@@ -53,7 +53,7 @@ jobs:
         run: echo "::set-output name=tag::$(date +'%Y%m%d%H%M%S')-${GITHUB_SHA}"
 
       - name: Publish Docker image to ECR registry
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' || contains(github.event.head_commit.message, 'DEPLOY NOW')
         env:
           DOCKER_IMAGE_TAG: ${{ steps.dockerImageTag.outputs.tag }}
         working-directory: application
@@ -83,7 +83,7 @@ jobs:
     name: Deploy Todo App
     needs: build-and-publish
     timeout-minutes: 15
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || contains(github.event.head_commit.message, 'DEPLOY NOW')
     concurrency: todo-application-deployment
     steps:
 

--- a/.github/workflows/04-publish-todo-app.yml
+++ b/.github/workflows/04-publish-todo-app.yml
@@ -1,4 +1,4 @@
-# This workflow builds the Docker image for the Todo-App and dispatches an SQS event to schedule the deployment.
+# This workflow builds the Docker image for the Todo-App and then deploys the application.
 name: 04 - Publish Todo-App
 
 env:

--- a/cdk/src/main/java/dev/stratospheric/todoapp/cdk/ServiceApp.java
+++ b/cdk/src/main/java/dev/stratospheric/todoapp/cdk/ServiceApp.java
@@ -104,8 +104,11 @@ public class ServiceApp {
           environmentName))
         .withTaskRolePolicyStatements(List.of(
           PolicyStatement.Builder.create()
+            .sid("Allow SQS Access")
             .effect(Effect.ALLOW)
-            .resources(singletonList("*"))
+            .resources(List.of(
+              String.format("arn:aws:sqs:%s:%s:%s", region, accountId, messagingOutputParameters.getTodoSharingQueueName())
+            ))
             .actions(Arrays.asList(
               "sqs:DeleteMessage",
               "sqs:GetQueueUrl",
@@ -118,9 +121,10 @@ public class ServiceApp {
               "sqs:GetQueueAttributes"))
             .build(),
           PolicyStatement.Builder.create()
+            .sid("Allow Creating Users in Cognito User Pool")
             .effect(Effect.ALLOW)
             .resources(
-              List.of(String.format("arn:aws:cognito-idp:%s:%s:userpool/%s", accountId, region, cognitoOutputParameters.getUserPoolId()))
+              List.of(String.format("arn:aws:cognito-idp:%s:%s:userpool/%s", region, accountId, cognitoOutputParameters.getUserPoolId()))
             )
             .actions(List.of(
               "cognito-idp:AdminCreateUser"
@@ -130,7 +134,7 @@ public class ServiceApp {
             .sid("Allow Sending Emails via SES")
             .effect(Effect.ALLOW)
             .resources(
-              List.of(String.format("arn:aws:ses:%s:%s:identity/stratospheric.dev", accountId, region))
+              List.of(String.format("arn:aws:ses:%s:%s:identity/stratospheric.dev", region, accountId))
             )
             .actions(List.of(
               "ses:SendEmail",
@@ -139,12 +143,12 @@ public class ServiceApp {
             .build(),
           PolicyStatement.Builder.create()
             .effect(Effect.ALLOW)
-            .resources(singletonList("*"))
+            .resources(singletonList("*")) // TODO: Fix once we manage the table with a CDK Construct
             .actions(singletonList("dynamodb:*"))
             .build(),
           PolicyStatement.Builder.create()
             .effect(Effect.ALLOW)
-            .resources(singletonList("*"))
+            .resources(singletonList("*")) // CloudWatch does not have any resource-level permissions, see https://stackoverflow.com/a/38055068/9085273
             .actions(singletonList("cloudwatch:PutMetricData"))
             .build()
         ))

--- a/cdk/src/main/java/dev/stratospheric/todoapp/cdk/ServiceApp.java
+++ b/cdk/src/main/java/dev/stratospheric/todoapp/cdk/ServiceApp.java
@@ -119,8 +119,12 @@ public class ServiceApp {
             .build(),
           PolicyStatement.Builder.create()
             .effect(Effect.ALLOW)
-            .resources(singletonList("*"))
-            .actions(singletonList("cognito-idp:*"))
+            .resources(
+              List.of(String.format("arn:aws:cognito-idp:%s:%s:userpool/%s", accountId, region, cognitoOutputParameters.getUserPoolId()))
+            )
+            .actions(List.of(
+              "cognito-idp:AdminCreateUser"
+            ))
             .build(),
           PolicyStatement.Builder.create()
             .sid("Allow Sending Emails via SES")

--- a/cdk/src/main/java/dev/stratospheric/todoapp/cdk/ServiceApp.java
+++ b/cdk/src/main/java/dev/stratospheric/todoapp/cdk/ServiceApp.java
@@ -123,9 +123,15 @@ public class ServiceApp {
             .actions(singletonList("cognito-idp:*"))
             .build(),
           PolicyStatement.Builder.create()
+            .sid("Allow Sending Emails via SES")
             .effect(Effect.ALLOW)
-            .resources(singletonList("*"))
-            .actions(singletonList("ses:*"))
+            .resources(
+              List.of(String.format("arn:aws:ses:%s:%s:identity/stratospheric.dev", accountId, region))
+            )
+            .actions(List.of(
+              "ses:SendEmail",
+              "ses:SendRawEmail"
+            ))
             .build(),
           PolicyStatement.Builder.create()
             .effect(Effect.ALLOW)

--- a/cdk/src/main/java/dev/stratospheric/todoapp/cdk/ServiceApp.java
+++ b/cdk/src/main/java/dev/stratospheric/todoapp/cdk/ServiceApp.java
@@ -144,8 +144,17 @@ public class ServiceApp {
           PolicyStatement.Builder.create()
             .sid("AllowDynamoTableAccess")
             .effect(Effect.ALLOW)
-            .resources(singletonList("*")) // TODO: Fix once we manage the table with a CDK Construct
-            .actions(singletonList("dynamodb:*"))
+            .resources(
+              List.of(String.format("arn:aws:dynamodb:%s:%s:table/%s", region, accountId, applicationEnvironment.prefix("breadcrumbs")))
+            )
+            .actions(List.of(
+              "dynamodb:Scan",
+              "dynamodb:Query",
+              "dynamodb:PutItem",
+              "dynamodb:GetItem",
+              "dynamodb:BatchWriteItem",
+              "dynamodb:BatchWriteGet"
+              ))
             .build(),
           PolicyStatement.Builder.create()
             .sid("AllowSendingMetricsToCloudWatch")

--- a/cdk/src/main/java/dev/stratospheric/todoapp/cdk/ServiceApp.java
+++ b/cdk/src/main/java/dev/stratospheric/todoapp/cdk/ServiceApp.java
@@ -104,7 +104,7 @@ public class ServiceApp {
           environmentName))
         .withTaskRolePolicyStatements(List.of(
           PolicyStatement.Builder.create()
-            .sid("Allow SQS Access")
+            .sid("AllowSQSAccess")
             .effect(Effect.ALLOW)
             .resources(List.of(
               String.format("arn:aws:sqs:%s:%s:%s", region, accountId, messagingOutputParameters.getTodoSharingQueueName())
@@ -121,7 +121,7 @@ public class ServiceApp {
               "sqs:GetQueueAttributes"))
             .build(),
           PolicyStatement.Builder.create()
-            .sid("Allow Creating Users in Cognito User Pool")
+            .sid("AllowCreatingUsers")
             .effect(Effect.ALLOW)
             .resources(
               List.of(String.format("arn:aws:cognito-idp:%s:%s:userpool/%s", region, accountId, cognitoOutputParameters.getUserPoolId()))
@@ -131,7 +131,7 @@ public class ServiceApp {
             ))
             .build(),
           PolicyStatement.Builder.create()
-            .sid("Allow Sending Emails via SES")
+            .sid("AllowSendingEmails")
             .effect(Effect.ALLOW)
             .resources(
               List.of(String.format("arn:aws:ses:%s:%s:identity/stratospheric.dev", region, accountId))
@@ -142,11 +142,13 @@ public class ServiceApp {
             ))
             .build(),
           PolicyStatement.Builder.create()
+            .sid("AllowDynamoTableAccess")
             .effect(Effect.ALLOW)
             .resources(singletonList("*")) // TODO: Fix once we manage the table with a CDK Construct
             .actions(singletonList("dynamodb:*"))
             .build(),
           PolicyStatement.Builder.create()
+            .sid("AllowSendingMetricsToCloudWatch")
             .effect(Effect.ALLOW)
             .resources(singletonList("*")) // CloudWatch does not have any resource-level permissions, see https://stackoverflow.com/a/38055068/9085273
             .actions(singletonList("cloudwatch:PutMetricData"))

--- a/chapters/chapter-10/cdk/src/main/java/dev/stratospheric/todoapp/cdk/ServiceApp.java
+++ b/chapters/chapter-10/cdk/src/main/java/dev/stratospheric/todoapp/cdk/ServiceApp.java
@@ -16,7 +16,6 @@ import software.amazon.awscdk.services.iam.Effect;
 import software.amazon.awscdk.services.iam.PolicyStatement;
 
 import static dev.stratospheric.todoapp.cdk.Validations.requireNonEmpty;
-import static java.util.Collections.singletonList;
 
 public class ServiceApp {
 
@@ -68,10 +67,16 @@ public class ServiceApp {
       .withHealthCheckIntervalSeconds(30)
       .withTaskRolePolicyStatements(List.of(
         PolicyStatement.Builder.create()
+          .sid("AllowCreatingUsers")
           .effect(Effect.ALLOW)
-          .resources(singletonList("*"))
-          .actions(singletonList("cognito-idp:*"))
-          .build()));
+          .resources(
+            List.of(String.format("arn:aws:cognito-idp:%s:%s:userpool/%s", region, accountId, cognitoOutputParameters.getUserPoolId()))
+          )
+          .actions(List.of(
+            "cognito-idp:AdminCreateUser"
+          ))
+          .build())
+      );
 
     Service service = new Service(
       serviceStack,


### PR DESCRIPTION
In the IAM chapter, we advocate for the principle of least privilege, but we don't follow that principle in our CDK stacks (because we're using wildcards).

This PR fixes all our wildcards (`*`) by limiting the access only to the required permissions and resources.

I've tested the deployed version and all use cases that interact with these AWS services work as expected 👍 