### PR TITLE
Binding result parameter must immediately follow object being validated

### DIFF
--- a/application/src/main/java/dev/stratospheric/todoapp/todo/TodoController.java
+++ b/application/src/main/java/dev/stratospheric/todoapp/todo/TodoController.java
@@ -53,8 +53,8 @@ public class TodoController {
   @PostMapping
   public String add(
     @Valid Todo toBeCreatedTodo,
-    @AuthenticationPrincipal OidcUser user,
     BindingResult bindingResult,
+    @AuthenticationPrincipal OidcUser user,
     Model model,
     RedirectAttributes redirectAttributes
   ) {


### PR DESCRIPTION
Invalid form data is causing a 400 error; swap 2nd and 3rd handler method parameters to enable validation and error messages.