### PR TITLE
add continuous test and startup checks

### DIFF
--- a/.github/workflows/continuous-verification.yml
+++ b/.github/workflows/continuous-verification.yml
@@ -1,0 +1,55 @@
+# Without continuously working on the source code, we may encounter startup/test issues
+# quite late. That's why we regularly run at least all tests and verify that the
+# application can be started in local development mode
+name: Continuously verify the projects can be build
+
+on:
+  schedule:
+    - cron: '0 5 * * SUN' # Every Sunday at 5 AM
+  workflow_dispatch:
+
+jobs:
+  build-and-test-applications:
+    strategy:
+      fail-fast: false
+      matrix:
+        folder: [ 'application', 'chapters/chapter-1/application', 'chapters/chapter-6/application', 'chapters/chapter-10/application', 'chapters/chapter-11/application', 'chapters/chapter-12/application', 'getting-started-with-spring-boot-on-aws' ]
+    runs-on: ubuntu-20.04
+    name: Deploy the application within the ${{ matrix.folder }} folder
+    steps:
+
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: 'gradle'
+
+      - name: Build and test the application
+        working-directory: ${{ matrix.folder }}
+        run: ./gradlew build --stacktrace
+
+  verify-local-development-mode:
+    runs-on: ubuntu-20.04
+    name: Ensure we can start the sample application locally
+    steps:
+
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: 'gradle'
+
+      - name: Start the local environment and verify the application startup
+        working-directory: application
+        run: |
+          docker compose up -d
+          ./gradlew bootRun &
+          timeout 60 .github/workflows/health-check.sh 8080

--- a/.github/workflows/continuous-verification.yml
+++ b/.github/workflows/continuous-verification.yml
@@ -4,7 +4,6 @@
 name: Continuously verify the projects can be build
 
 on:
-  push:
   schedule:
     - cron: '0 5 * * SUN' # Every Sunday at 5 AM
   workflow_dispatch:

--- a/.github/workflows/continuous-verification.yml
+++ b/.github/workflows/continuous-verification.yml
@@ -4,6 +4,7 @@
 name: Continuously verify the projects can be build
 
 on:
+  push:
   schedule:
     - cron: '0 5 * * SUN' # Every Sunday at 5 AM
   workflow_dispatch:

--- a/.github/workflows/continuous-verification.yml
+++ b/.github/workflows/continuous-verification.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         folder: [ 'application', 'chapters/chapter-1/application', 'chapters/chapter-6/application', 'chapters/chapter-10/application', 'chapters/chapter-11/application', 'chapters/chapter-12/application', 'getting-started-with-spring-boot-on-aws' ]
     runs-on: ubuntu-20.04
-    name: Deploy the application within the ${{ matrix.folder }} folder
+    name: Test ${{ matrix.folder }}
     steps:
 
       - name: Checkout code
@@ -53,4 +53,4 @@ jobs:
         run: |
           docker compose up -d
           ./gradlew bootRun &
-          timeout 60 .github/workflows/health-check.sh 8080
+          timeout 60 ../.github/workflows/health-check.sh 8080

--- a/.github/workflows/continuous-verification.yml
+++ b/.github/workflows/continuous-verification.yml
@@ -35,7 +35,7 @@ jobs:
 
   verify-local-development-mode:
     runs-on: ubuntu-20.04
-    name: Ensure we can start the sample application locally
+    name: Verify local development mode
     steps:
 
       - name: Checkout code
@@ -54,3 +54,10 @@ jobs:
           docker compose up -d
           ./gradlew bootRun &
           timeout 60 ../.github/workflows/health-check.sh 8080
+
+      - name: Stop local environment
+        working-directory: application
+        if: always()
+        run: |
+          docker compose logs
+          docker compose down

--- a/.github/workflows/health-check.sh
+++ b/.github/workflows/health-check.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+#
+# Bash shell script to determine the uptime of a service by verifying the
+# HTTP response code of the /actuator/health endpoint (expected status is 200.
+#
+# Usage ./health-check.sh PORT -> ./health-check.sh 8080
+#
+# To fail the health check after X seconds, wrap the execution of this script with timeout
+# e.g. timeout 30 ./.github/workflows/health-check.sh 8080
+
+# Bash 'strict mode' see http://redsymbol.net/articles/unofficial-bash-strict-mode/
+set -euo pipefail
+IFS=$'\n\t'
+
+PORT=$1
+HEALTH_ENDPOINT="localhost:$PORT/actuator/health"
+RETRY_TIMEOUT_SECONDS=5
+
+while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' $HEALTH_ENDPOINT)" != "200" ]];
+do
+  echo "Service not healthy yet ($HEALTH_ENDPOINT). Trying again in $RETRY_TIMEOUT_SECONDS second(s)"
+  sleep $RETRY_TIMEOUT_SECONDS
+done
+
+echo "Service is up- and running at $HEALTH_ENDPOINT."


### PR DESCRIPTION
To ensure our different application states can be built and readers can start the sample application in development mode, we at least run tests once a week.