### PR TITLE
fix: Replace SecretValue#toString usage

### DIFF
--- a/cdk/src/main/java/dev/stratospheric/todoapp/cdk/ServiceApp.java
+++ b/cdk/src/main/java/dev/stratospheric/todoapp/cdk/ServiceApp.java
@@ -198,9 +198,9 @@ public class ServiceApp {
         databaseOutputParameters.getEndpointPort(),
         databaseOutputParameters.getDbName()));
     vars.put("SPRING_DATASOURCE_USERNAME",
-      databaseSecret.secretValueFromJson("username").toString());
+      databaseSecret.secretValueFromJson("username").unsafeUnwrap());
     vars.put("SPRING_DATASOURCE_PASSWORD",
-      databaseSecret.secretValueFromJson("password").toString());
+      databaseSecret.secretValueFromJson("password").unsafeUnwrap());
     vars.put("COGNITO_CLIENT_ID", cognitoOutputParameters.getUserPoolClientId());
     vars.put("COGNITO_CLIENT_SECRET", cognitoOutputParameters.getUserPoolClientSecret());
     vars.put("COGNITO_USER_POOL_ID", cognitoOutputParameters.getUserPoolId());

--- a/chapters/chapter-11/cdk/src/main/java/dev/stratospheric/todoapp/cdk/ServiceApp.java
+++ b/chapters/chapter-11/cdk/src/main/java/dev/stratospheric/todoapp/cdk/ServiceApp.java
@@ -102,9 +102,9 @@ public class ServiceApp {
         databaseOutputParameters.getEndpointPort(),
         databaseOutputParameters.getDbName()));
     vars.put("SPRING_DATASOURCE_USERNAME",
-      databaseSecret.secretValueFromJson("username").toString());
+      databaseSecret.secretValueFromJson("username").unsafeUnwrap());
     vars.put("SPRING_DATASOURCE_PASSWORD",
-      databaseSecret.secretValueFromJson("password").toString());
+      databaseSecret.secretValueFromJson("password").unsafeUnwrap());
 
     return vars;
   }

--- a/chapters/chapter-12/cdk/src/main/java/dev/stratospheric/todoapp/cdk/ServiceApp.java
+++ b/chapters/chapter-12/cdk/src/main/java/dev/stratospheric/todoapp/cdk/ServiceApp.java
@@ -156,9 +156,9 @@ public class ServiceApp {
         databaseOutputParameters.getEndpointPort(),
         databaseOutputParameters.getDbName()));
     vars.put("SPRING_DATASOURCE_USERNAME",
-      databaseSecret.secretValueFromJson("username").toString());
+      databaseSecret.secretValueFromJson("username").unsafeUnwrap());
     vars.put("SPRING_DATASOURCE_PASSWORD",
-      databaseSecret.secretValueFromJson("password").toString());
+      databaseSecret.secretValueFromJson("password").unsafeUnwrap());
 
     vars.put("COGNITO_CLIENT_ID", cognitoOutputParameters.getUserPoolClientId());
     vars.put("COGNITO_CLIENT_SECRET", cognitoOutputParameters.getUserPoolClientSecret());


### PR DESCRIPTION
During Service construct deployment following exception is rising:
```
Error: Exception in thread "main" java.lang.RuntimeException:  
Error: Resolution error: Resolution error: Resolution error: Synthing a secret value to Resources/${Token[ServiceStack.Service.taskDefinition.LogicalID.779]}/Properties/containerDefinitions/0/environment/2/value.  
Using a SecretValue here risks exposing your secret.  
Only pass SecretValues to constructs that accept a SecretValue property, or call AWS Secrets Manager directly in your runtime code.  
Call 'secretValue.unsafeUnwrap()' if you understand and accept the risks..
```
Using `toString` on secrets seems to be no longer accepted without calling `unsafeUnwrap` first, hence I'm proposing to replace `SecretValue#toString` usage with usage of `SecretValue#unsafeUnwrap`.

Note:
I'm using Gradle for CDK code building.