### PR TITLE
[#237] Link to the non-transparent image for the technical architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ We don't stop here. Once our application is running in production, things are ge
 
 ## What We're Going to Build
 
-![Stratospheric Technical Architecture](https://stratospheric.dev/images/application/stratospheric-technical-architecture-transparent.png)
+![Stratospheric Technical Architecture](https://stratospheric.dev/images/application/stratospheric-technical-architecture.png)
 
 ## What It's Going to Look Like
 


### PR DESCRIPTION
Replace the link in README.md to the transparent image of the technical architecture with the non-transparent one.
This is the fix for Issue #237 .