### PR TITLE
multiple fixes with latest CDK and cognito

### DIFF
--- a/chapters/chapter-10/application/src/main/java/dev/stratospheric/config/LogoutSuccessHandlerConfig.java
+++ b/chapters/chapter-10/application/src/main/java/dev/stratospheric/config/LogoutSuccessHandlerConfig.java
@@ -15,7 +15,7 @@ public class LogoutSuccessHandlerConfig {
   @ConditionalOnProperty(prefix = "custom", name = "use-cognito-as-identity-provider", havingValue = "true")
   public LogoutSuccessHandler cognitoOidcLogoutSuccessHandler(
     @Value("${COGNITO_CLIENT_ID}") String clientId,
-    @Value("${COGNITO_USER_POOL_LOGOUT_URL}") String userPoolLogoutUrl) {
+    @Value("${COGNITO_LOGOUT_URL}") String userPoolLogoutUrl) {
     return new CognitoOidcLogoutSuccessHandler(userPoolLogoutUrl, clientId);
   }
 

--- a/chapters/chapter-10/cdk/cdk.json
+++ b/chapters/chapter-10/cdk/cdk.json
@@ -5,7 +5,7 @@
     "accountId": "221875718260",
     "environmentName": "staging",
     "springProfile": "aws",
-    "dockerImageUrl": "docker.io/stratospheric/todo-app-v1:latest",
+    "dockerImageUrl": "docker.io/stratospheric/todo-app-v2:latest",
     "applicationUrl": "https://app.stratospheric.dev",
     "loginPageDomainPrefix": "staging-stratospheric",
     "sslCertificateArn": "arn:aws:acm:eu-central-1:221875718260:certificate/8d92169c-ea74-4086-b407-b951429ac2b1"

--- a/chapters/chapter-10/cdk/package.json
+++ b/chapters/chapter-10/cdk/package.json
@@ -9,8 +9,8 @@
     "network:destroy": "cdk destroy --app \"./mvnw -e -q compile exec:java -Dexec.mainClass=dev.stratospheric.todoapp.cdk.NetworkApp\" --force --require-approval never",
     "repository:deploy": "cdk deploy --app \"./mvnw -e -q compile exec:java -Dexec.mainClass=dev.stratospheric.todoapp.cdk.DockerRepositoryApp\" --require-approval never",
     "repository:destroy": "cdk destroy --app \"./mvnw -e -q compile exec:java -Dexec.mainClass=dev.stratospheric.todoapp.cdk.DockerRepositoryApp\" --force --require-approval never",
-    "service:deploy": "cdk deploy --app \"./mvnw -e -q compile exec:java -Dexec.mainClass=dev.stratospheric.todoapp.cdk.ServiceApp\" --require-approval never",
-    "service:destroy": "cdk destroy --app \"./mvnw -e -q compile exec:java -Dexec.mainClass=dev.stratospheric.todoapp.cdk.ServiceApp\" --force --require-approval never",
+    "service:deploy": "cdk deploy --app \"./mvnw -e -q compile exec:java -Dexec.mainClass=dev.stratospheric.todoapp.cdk.ServiceApp\" --require-approval never --all",
+    "service:destroy": "cdk destroy --app \"./mvnw -e -q compile exec:java -Dexec.mainClass=dev.stratospheric.todoapp.cdk.ServiceApp\" --force --require-approval never --all",
     "cognito:deploy": "cdk deploy --app \"./mvnw -e -q compile exec:java -Dexec.mainClass=dev.stratospheric.todoapp.cdk.CognitoApp\" --require-approval never",
     "cognito:destroy": "cdk destroy --app \"./mvnw -e -q compile exec:java -Dexec.mainClass=dev.stratospheric.todoapp.cdk.CognitoApp\" --force --require-approval never"
   },

--- a/chapters/chapter-10/cdk/src/main/java/dev/stratospheric/todoapp/cdk/CognitoStack.java
+++ b/chapters/chapter-10/cdk/src/main/java/dev/stratospheric/todoapp/cdk/CognitoStack.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.Map;
 
 import dev.stratospheric.cdk.ApplicationEnvironment;
+import dev.stratospheric.cdk.Network;
 import software.amazon.awscdk.Duration;
 import software.amazon.awscdk.Environment;
 import software.amazon.awscdk.Stack;
@@ -78,6 +79,8 @@ public class CognitoStack extends Stack {
         .build())
       .build();
 
+    Network.NetworkOutputParameters networkOutputParameters = Network.getOutputParametersFromParameterStore(this, applicationEnvironment.getEnvironmentName());
+
     this.userPoolClient = UserPoolClient.Builder.create(this, "userPoolClient")
       .userPoolClientName(inputParameters.applicationName + "-client")
       .generateSecret(true)
@@ -85,6 +88,7 @@ public class CognitoStack extends Stack {
       .oAuth(OAuthSettings.builder()
         .callbackUrls(Arrays.asList(
           String.format("%s/login/oauth2/code/cognito", inputParameters.applicationUrl),
+          String.format("https://%s/login/oauth2/code/cognito", networkOutputParameters.getLoadBalancerDnsName()),
           "http://localhost:8080/login/oauth2/code/cognito"
         ))
         .logoutUrls(Arrays.asList(inputParameters.applicationUrl, "http://localhost:8080"))

--- a/chapters/chapter-10/cdk/src/main/java/dev/stratospheric/todoapp/cdk/CognitoStack.java
+++ b/chapters/chapter-10/cdk/src/main/java/dev/stratospheric/todoapp/cdk/CognitoStack.java
@@ -91,7 +91,11 @@ public class CognitoStack extends Stack {
           String.format("https://%s/login/oauth2/code/cognito", networkOutputParameters.getLoadBalancerDnsName()),
           "http://localhost:8080/login/oauth2/code/cognito"
         ))
-        .logoutUrls(Arrays.asList(inputParameters.applicationUrl, "http://localhost:8080"))
+        .logoutUrls(Arrays.asList(
+          inputParameters.applicationUrl,
+          "http://localhost:8080",
+            "https://" + networkOutputParameters.getLoadBalancerDnsName()
+        ))
         .flows(OAuthFlows.builder()
           .authorizationCodeGrant(true)
           .build())

--- a/chapters/chapter-10/cdk/src/main/java/dev/stratospheric/todoapp/cdk/ServiceApp.java
+++ b/chapters/chapter-10/cdk/src/main/java/dev/stratospheric/todoapp/cdk/ServiceApp.java
@@ -65,6 +65,7 @@ public class ServiceApp {
     Network.NetworkOutputParameters networkOutputParameters = Network.getOutputParametersFromParameterStore(serviceStack, applicationEnvironment.getEnvironmentName());
     Service.ServiceInputParameters serviceInputParameters = new Service.ServiceInputParameters(dockerImageSource,Collections.emptyList(), environmentVariables(springProfile, cognitoOutputParameters))
       .withHealthCheckIntervalSeconds(30)
+      .withStickySessionsEnabled(true)
       .withTaskRolePolicyStatements(List.of(
         PolicyStatement.Builder.create()
           .sid("AllowCreatingUsers")


### PR DESCRIPTION
I tried to deploy chapter 10 to my AWS account, but the application wasn't working for multiple reasons

1. It deploys the stratospheric-v1 docker image, that was built from the previous chapter and has no authentication in it. There seems to be no v2 image in dockerhub, so if you agree with this approach then could you please build and publish one?
2. fix to run stack with latest CDK commandline
3. Fix misspelled property name
4. Register loadbalancer URL with cognito. I don't have a domain name so at least I could test through the loadbalancer URL
5. Fix broken authentication by enabling sticky session (this took some while to debug)